### PR TITLE
Fix cat_merge output option examples

### DIFF
--- a/docs/html/index.html
+++ b/docs/html/index.html
@@ -285,11 +285,11 @@ Cat_Merge Code</h2>
 <p><b>Run</b></p>
 <p>To run simply specify the input file name and the desired output file name as follows:</p>
 <blockquote class="doxtable">
-<p>&gt;&gt; cat_merge &ndash;input_file FILE_NAME &ndash;ouput_file MERGED_CLUSTERS </p>
+<p>&gt;&gt; cat_merge &ndash;input_file FILE_NAME &ndash;output_file MERGED_CLUSTERS </p>
 </blockquote>
 <p>In order to provide signal-to-noise ratio values for each of the clusters the <em>bg_data</em> option must also be used as follows:</p>
 <blockquote class="doxtable">
-<p>&gt;&gt; cat_merge &ndash;input_file FILE_NAME &ndash;ouput_file MERGED_CLUSTERS &ndash;bg_data BG_DATA_FILE </p>
+<p>&gt;&gt; cat_merge &ndash;input_file FILE_NAME &ndash;output_file MERGED_CLUSTERS &ndash;bg_data BG_DATA_FILE </p>
 </blockquote>
 <p><b>Code Options</b></p>
 <ul>

--- a/docs/readme.md
+++ b/docs/readme.md
@@ -383,14 +383,14 @@ To run simply specify the input file name and the desired output file
 name as follows:
 
 ```bash
-$ cat_merge --input_file FILE_NAME --ouput_file MERGED_CLUSTERS
+$ cat_merge --input_file FILE_NAME --output_file MERGED_CLUSTERS
 ```
 
 In order to provide signal-to-noise ratio values for each of the
 clusters the `bg_data` option must also be used as follows:
 
 ```bash
-$ cat_merge --input_file FILE_NAME --ouput_file MERGED_CLUSTERS --bg_data BG_DATA_FILE
+$ cat_merge --input_file FILE_NAME --output_file MERGED_CLUSTERS --bg_data BG_DATA_FILE
 ```
 
 **Code Options**


### PR DESCRIPTION
## Summary
- fix the `cat_merge` examples to use `--output_file`
- keep the generated HTML docs in sync with `docs/readme.md`

## Validation
- confirmed `sfof/src/option_class.cpp` registers `output_file,o`
- `rg -n 'ouput_file|output_file|cat_merge --input_file|cat_merge &ndash;input_file|read_merge_opts' docs/readme.md docs/html/index.html sfof/src/option_class.cpp -S`
- `git diff --check`

No runtime tests were run; this only updates documentation command examples.
